### PR TITLE
Stop creating new objects after edit

### DIFF
--- a/ToDoApp/mytodo/views.py
+++ b/ToDoApp/mytodo/views.py
@@ -35,7 +35,7 @@ def edit_todo(request, todo_id):
     todo_obj = ToDo.objects.get(pk=todo_id)
 
     if request.method == 'POST':
-        form = ToDoForm(request.POST)
+        form = ToDoForm(request.POST, initial={'todo_text': todo_obj.todo_text})
         if form.is_valid():
             todo_obj.todo_text = form.cleaned_data.get('todo_text')
             todo_obj.save()


### PR DESCRIPTION
After updating an existing todo object, it created a new todo object.
Added instance of the existing object, so that it doesn't create new objects.